### PR TITLE
NO-ISSUE: Fixing PHP 5.5 deprecation notice on sfTask

### DIFF
--- a/lib/task/sfTask.class.php
+++ b/lib/task/sfTask.class.php
@@ -304,7 +304,15 @@ abstract class sfTask
    */
   public function getDetailedDescription()
   {
-    return preg_replace('/\[(.+?)\|(\w+)\]/se', '$this->formatter->format("$1", "$2")', $this->detailedDescription);
+      $formatter = $this->formatter;
+      return preg_replace_callback(
+          '/\[(.+?)\|(\w+)\]/s',
+          function($matches) use ($formatter)
+          {
+              return $formatter->format($matches[1], $matches[2]);
+          },
+          $this->detailedDescription
+      );
   }
 
   /**


### PR DESCRIPTION
Was giving a deprecation notice when running ``php symfony help TASK``

```
PHP Deprecated:  preg_replace(): The /e modifier is deprecated, use preg_replace_callback instead in /var/www/smarkio-base/lib/vendor/smarkio/symfony1/lib/task/sfTask.class.php on line 307

Deprecated: preg_replace(): The /e modifier is deprecated, use preg_replace_callback instead in /var/www/smarkio-base/lib/vendor/smarkio/symfony1/lib/task/sfTask.class.php on line 307
Usage:
 symfony smarkio:billing [--application="..."] [--env="..."] [--connection="..."] [--date_start[="..."]] [--date_end[="..."]] [-C|--client[="..."]] [email]
```

> Release minor version

cc @smarkio/developers 