### PR TITLE
NO-ISSUE: sfValidatorUrl - new TLDs support

### DIFF
--- a/lib/validator/sfValidatorUrl.class.php
+++ b/lib/validator/sfValidatorUrl.class.php
@@ -21,7 +21,7 @@ class sfValidatorUrl extends sfValidatorRegex
   const REGEX_URL_FORMAT = '~^
       (%s)://                                 # protocol
       (
-        ([a-z0-9-]+\.)+[a-z]{2,6}             # a domain name
+        ([a-z0-9-]+\.)+[a-z]{2,16}             # a domain name
           |                                   #  or
         \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}    # a IP address
       )


### PR DESCRIPTION
sfValidatorUrl was requiring that the TLD had only a maximum of 6 characters. Ex: impacting.digital wouldn't work.
This PR increases that limit to 16 chars.

> Once this is merged and a patch release created, let me know to change the dependency on smarkio-base

cc @smarkio/developers 